### PR TITLE
feat(reader): add support for read replica

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -2,13 +2,28 @@ import type { PrismaClient } from "@prisma/client/extension";
 import { DatabaseConnection, Driver, TransactionSettings } from "kysely";
 import { PrismaConnection } from "./connection.js";
 
+export type PrismaKyselyExtensionDriverConfig = {
+  /**
+   * Use a read replica for read queries when enabled
+   * @see @prisma/extension-read-replicas
+   */
+  withReadReplica?: boolean;
+};
+
 export class PrismaDriver<T extends PrismaClient> implements Driver {
-  constructor(private readonly prisma: T) {}
+  protected config: PrismaKyselyExtensionDriverConfig = {};
+
+  constructor(
+    private readonly prisma: T,
+    config: PrismaKyselyExtensionDriverConfig = {},
+  ) {
+    this.config = config;
+  }
 
   async init(): Promise<void> {}
 
   async acquireConnection(): Promise<DatabaseConnection> {
-    return new PrismaConnection(this.prisma);
+    return new PrismaConnection(this.prisma, this.config);
   }
 
   async beginTransaction(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Prisma } from "@prisma/client";
 import { Kysely } from "kysely";
-import { PrismaDriver } from "./driver.js";
+import { PrismaDriver, PrismaKyselyExtensionDriverConfig } from "./driver.js";
 
 /**
  * The configuration object for the Prisma Kysely extension
@@ -11,16 +11,22 @@ export type PrismaKyselyExtensionArgs<Database> = {
    * The Kysely instance to provide to the Prisma client
    */
   // kysely: Kysely<Database>;
-  kysely: (driver: PrismaDriver<any>) => Kysely<Database>;
+  kysely: (
+    driver: PrismaDriver<any>,
+    config?: PrismaKyselyExtensionDriverConfig,
+  ) => Kysely<Database>;
 };
 
 /**
  * Define a Prisma extension that adds Kysely query builder methods to the Prisma client
  * @param extensionArgs The extension configuration object
  */
-export default <Database>(extensionArgs: PrismaKyselyExtensionArgs<Database>) =>
+export default <Database>(
+  extensionArgs: PrismaKyselyExtensionArgs<Database>,
+  config = {},
+) =>
   Prisma.defineExtension((client) => {
-    const driver = new PrismaDriver(client);
+    const driver = new PrismaDriver(client, config);
     const kysely = extensionArgs.kysely(driver);
 
     const extendedClient = client.$extends({


### PR DESCRIPTION
Hey!

We had a big problem in our production setup where all raw prisma-kysely queries hit our writer db, even for read-only operations. With this proposed solution, one can pass a configuration object to the extension to opt-in to use the replica instance for read queries.

I already used this implementation in our prod setup and our writer instance immediately cooled down :)

Johann