### PR TITLE
feat: throw error if Prisma client is already extended with Kysely

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,15 @@ export type PrismaKyselyExtensionArgs<Database> = {
    * The Kysely instance to provide to the Prisma client
    */
   // kysely: Kysely<Database>;
-  kysely: (driver: PrismaDriver<any>) => Kysely<Database>;
+  kysely: (driver: PrismaDriver<unknown>) => Kysely<Database>;
 };
+
+export class PrismaKyselyExtensionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PrismaKyselyExtensionError";
+  }
+}
 
 /**
  * Define a Prisma extension that adds Kysely query builder methods to the Prisma client
@@ -20,6 +27,13 @@ export type PrismaKyselyExtensionArgs<Database> = {
  */
 export default <Database>(extensionArgs: PrismaKyselyExtensionArgs<Database>) =>
   Prisma.defineExtension((client) => {
+    // Check if the client is already extended
+    if ("$kysely" in client) {
+      throw new PrismaKyselyExtensionError(
+        "The Prisma client is already extended with Kysely",
+      );
+    }
+
     const driver = new PrismaDriver(client);
     const kysely = extensionArgs.kysely(driver);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -209,6 +209,24 @@ describe("prisma-extension-kysely", () => {
     );
   });
 
+  it("should throw an error if the Prisma client is already extended with Kysely", async () => {
+    expect(() =>
+      xprisma.$extends(
+        kyselyExtension({
+          kysely: (driver) =>
+            new Kysely<DB>({
+              dialect: {
+                createAdapter: () => new SqliteAdapter(),
+                createDriver: () => driver,
+                createIntrospector: (db) => new SqliteIntrospector(db),
+                createQueryCompiler: () => new SqliteQueryCompiler(),
+              },
+            }),
+        }),
+      ),
+    ).toThrow("The Prisma client is already extended with Kysely");
+  });
+
   describe("@prisma/extension-read-replicas", () => {
     const replica = new PrismaClient().$extends(
       kyselyExtension({


### PR DESCRIPTION
Added a check to throw an error if the Prisma client is already extended with Kysely. This change
prevents undefined behavior and ensures that the client is not extended multiple times. Introduced a
new test case to validate this behavior.

BREAKING CHANGE: This change introduces an error where previously there was none, which may affect
existing code that accidentally extended the Prisma client multiple times.
