### PR TITLE
chore: Specify version of Prisma Client peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     }
   },
   "peerDependencies": {
-    "@prisma/client": "latest"
+    "@prisma/client": ">=5.0.0 <6.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",


### PR DESCRIPTION
When setting peer dependency as "latest", package manager throw warnings about the prisma version. Added an version rango to allow any 5.x version.