### PR TITLE
fix(release): add breakingHeaderPattern to recognize feat! commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,26 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([\\w$@.\\-*/ ]*)\\))?!: (.*)$"
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
+          "breakingHeaderPattern": "^(\\w*)(?:\\(([\\w$@.\\-*/ ]*)\\))?!: (.*)$"
+        }
+      }
+    ],
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/npm", { "npmPublish": true }],
     [


### PR DESCRIPTION
## Summary

- The angular preset for `@semantic-release/commit-analyzer` only recognises `BREAKING CHANGE:` footer notes, not the `!` shorthand in the commit type (e.g. `feat!:`)
- Adds `breakingHeaderPattern` to both `commit-analyzer` and `release-notes-generator` so that `feat!:` / `fix(scope)!:` commits are correctly identified as major releases
- Needed to trigger the v4.0.0 release for the Prisma 7 support PR that was just merged

## Test plan

- [x] Merge this PR
- [ ] Manually trigger the Release workflow — should produce v4.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)