### PR TITLE
chore(deps): pin biome version to 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,8 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist",
-    "!**/*.tsbuildinfo"
-  ],
+  "sideEffects": false,
+  "files": ["dist", "!**/*.tsbuildinfo"],
   "scripts": {
     "pretest": "prisma db push && prisma generate",
     "test": "vitest run",
@@ -76,7 +74,7 @@
     "kysely": "^0.27.0 || ^0.28.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.4",
+    "@biomejs/biome": "2.4.4",
     "@commitlint/cli": "^20.0.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@commitlint/cz-commitlint": "^20.0.0",


### PR DESCRIPTION
## Summary
- Pin `@biomejs/biome` from `^2.4.4` to exact `2.4.4` to prevent new lint rules in minor releases from unexpectedly breaking CI
- Add `"sideEffects": false` to `package.json` for bundler tree-shaking

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (30 tests)
- [x] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)