### PR TITLE
fix(examples): add missing .js extension to ESM import

### DIFF
--- a/examples/esm/index.ts
+++ b/examples/esm/index.ts
@@ -7,7 +7,7 @@ import {
 } from "kysely";
 import kyselyExtension from "prisma-extension-kysely";
 import type { DB } from "./generated/kysely/types.js";
-import { PrismaClient } from "./generated/prisma/client";
+import { PrismaClient } from "./generated/prisma/client.js";
 
 const adapter = new PrismaBetterSqlite3({
   url: "file:./dev.db",


### PR DESCRIPTION
## Summary
- Add missing `.js` file extension to a relative import in the ESM example (`examples/esm/index.ts`) for correct ES module resolution

## Test plan
- [x] `npm run check` now passes without the `useImportExtensions` lint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)